### PR TITLE
Gen config cli

### DIFF
--- a/src/alp/cli.py
+++ b/src/alp/cli.py
@@ -191,7 +191,9 @@ def genconfig(conf, outdir, namesuf, portshift, rootfolder, controlers,
         if not os.path.exists(outdir):  # pragma: no cover
             os.makedirs(outdir)
 
-    alpapp, alpdb, containers = gen_all_configs(outdir, namesuf)
+    alpapp, alpdb, containers = gen_all_configs(outdir, namesuf, portshift,
+                                                rootfolder, controlers,
+                                                skworkers, kworkers)
 
     if conf.verbose:
         click.echo(click.style('Auto generated configuration:', fg=col_info))

--- a/src/alp/cli.py
+++ b/src/alp/cli.py
@@ -1,6 +1,7 @@
 """
 CLI to launch ALP services
 """
+import os
 import click
 import pandas as pd
 from docker import Client
@@ -10,6 +11,7 @@ from .cli_utils import action_config
 from .cli_utils import banner
 from .cli_utils import col_info
 from .cli_utils import col_warn
+from .cli_utils import gen_all_configs
 from .cli_utils import get_config_names
 from .cli_utils import open_config
 from .cli_utils import pass_config
@@ -162,3 +164,43 @@ def pull(conf, config):
     config = open_config(config)
     res = pull_config(config, conf.verbose)
     return res
+
+
+@main.command()
+@click.argument('namesuf', type=click.STRING, required=False, default='')
+@click.argument('portshift', type=click.INT, required=False, default=0)
+@click.argument('rootfolder', type=click.Path(exists=True), required=False)
+@click.argument('controlers', type=click.INT, required=False, default=1)
+@click.argument('skworkers', type=click.INT, required=False, default=1)
+@click.argument('kworkers', type=click.INT, required=False, default=1)
+@click.argument('outdir', type=click.Path(exists=True), required=False)
+@pass_config
+def genconfig(conf, namesuf, portshift, rootfolder, controlers, skworkers,
+              kworkers, outdir):
+    """Generate and write configurations files in .alp"""
+
+    click.echo(namesuf)
+    user_root = os.path.expanduser('~')
+
+    alpapp, alpdb, containers = gen_all_configs(namesuf)
+
+    if conf.verbose:
+        click.echo(containers)
+        click.echo(alpapp)
+        click.echo(alpdb)
+    # dump configs in .alp
+
+    alpapp_json = os.path.join(outdir, 'alpapp.json')
+    alpdb_json = os.path.join(outdir, 'alpdb.json')
+    containers_json = os.path.join(outdir, 'containers.json')
+
+    with open(alpapp_json, 'w') as f:
+        f.write(alpapp)
+
+    with open(alpdb_json, 'w') as f:
+        f.write(alpdb)
+
+    with open(containers_json, 'w') as f:
+        f.write(containers)
+
+    return 0

--- a/src/alp/cli.py
+++ b/src/alp/cli.py
@@ -196,11 +196,11 @@ def genconfig(conf, outdir, namesuf, portshift, rootfolder, controlers,
     if conf.verbose:
         click.echo(click.style('Auto generated configuration:', fg=col_info))
         click.echo(click.style(a_text('    Controlers', str(controlers)),
-                            fg=col_info))
+                               fg=col_info))
         click.echo(click.style(a_text('    Sklearn workers', str(skworkers)),
-                            fg=col_info))
+                               fg=col_info))
         click.echo(click.style(a_text('    Keras workers', str(kworkers)),
-                            fg=col_info))
+                               fg=col_info))
         click.echo()
 
     # dump configs in .alp

--- a/src/alp/cli_utils.py
+++ b/src/alp/cli_utils.py
@@ -473,6 +473,8 @@ def gen_containers_config(conf_folder, name_suffix='', port_shift=0,
         controler['container_name'] = 'tboquet/full7hc5controleralp'
         controler['NV_GPU'] = '0'
         controler['mode'] = '-d'
+        ports = [(440 + i + port_shift, 8888)]
+        controler['ports'] = ['{}:{}'.format(p1, p2) for p1, p2 in ports]
         controlers_list.append(controler)
 
     config = dict()
@@ -515,9 +517,11 @@ def gen_all_configs(conf_folder, name_suffix='', port_shift=0,
     alpapp = gen_alpapp_config(name_suffix, port_shift)
     alpdb = gen_alpdb_config(name_suffix)
     containers = gen_containers_config(conf_folder, name_suffix=name_suffix,
-                                       port_shift=0, root_folder=None,
-                                       controlers=1, workers_sklearn=1,
-                                       workers_keras=1)
+                                       port_shift=port_shift,
+                                       root_folder=root_folder,
+                                       controlers=controlers,
+                                       workers_sklearn=workers_sklearn,
+                                       workers_keras=workers_keras)
     alpapp_json = json.dumps(alpapp, indent=4)
     alpdb_json = json.dumps(alpdb, indent=4)
     containers_json = json.dumps(containers, indent=4)

--- a/src/alp/cli_utils.py
+++ b/src/alp/cli_utils.py
@@ -1,3 +1,4 @@
+import os
 import json
 import subprocess
 from subprocess import PIPE
@@ -358,6 +359,168 @@ def action_config(config, action, verbose=False, force=False):
         if err is not None:  # pragma: no cover
             res = False
     return res
+
+
+def make_volumes(root_folder, volumes):
+    t_volumes = ['{}:{}'.format(os.path.join(root_folder, v_root), c_root)
+                    for v_root, c_root in volumes]
+    return t_volumes
+
+
+def gen_containers_config(name_suffix='', port_shift=0, root_folder=None,
+                          controlers=1, workers_sklearn=1, workers_keras=1):
+    """ Generates containers config parsable with ALP CLI
+
+    This function generates a JSON configuration usable with ALP CLI.
+    It is possible to customize the configuration and change the names,
+    the ports, root folder where the data relative to each container will be
+    mounted and the number of workers and controlers.
+
+    Args:
+        name_suffix(str): the suffix to append to the name of each controler
+        port_shift(int): the shift to apply to the original ports. This shift
+            will be applied to the broker and the controlers.
+        root_folder(str): if None, the user root directory will be used. The
+            indicated directory will be used otherwise.
+        controlers(int): number of controler to be run.
+        workers_sklearn(int): number of scikit learn workers to be run.
+        workers keras(int): number of keras workers to be run.
+
+    .. note::
+
+        Choose the number of controlers and workers wisely for your system
+        to work properly. For now, the configuration will use the GPU 0 of the
+        system. The support for multiple GPU machine is straightforward and
+        will be added soon.
+    """
+    if len(name_suffix) > 0:
+        name_suffix = '_{}'.format(name_suffix)
+
+    config = dict()
+
+    if root_folder is None:
+        root_folder = os.path.expanduser('~')
+
+    # broker config
+    broker = dict()
+    volumes = [('rabbitmq/dev/log', '/dev/log'),
+               ('rabbitmq', '/var/lib/rabbitmq')]
+
+    t_volumes = make_volumes(root_folder, volumes)
+    broker['volumes'] = t_volumes
+    ports = [(8080 + port_shift, 15672), (5672 + port_shift, 5672)]
+    broker['ports'] = ['{}:{}'.format(p1, p2) for p1, p2 in ports]
+    broker['name'] = 'rabbitmq_sched{}'.format(name_suffix)
+    broker['container_name'] = 'rabbitmq:3-management'
+    broker['mode'] = '-d'
+
+    # results db config
+    result_db = dict()
+    volumes = [('mongo_data/results', '/data/db')]
+    t_volumes = make_volumes(root_folder, volumes)
+    result_db['volumes'] = t_volumes
+    result_db['name'] = 'mongo_results{}'.format(name_suffix)
+    result_db['container_name'] = 'mongo'
+    result_db['mode'] = '-d'
+
+    # results db config
+    model_db = dict()
+    volumes = [('mongo_data/models', '/data/db')]
+    t_volumes = make_volumes(root_folder, volumes)
+    model_db['volumes'] = t_volumes
+    model_db['name'] = 'mongo_models{}'.format(name_suffix)
+    model_db['container_name'] = 'mongo'
+    model_db['mode'] = '-d'
+
+    workers = []
+    for i in range(workers_sklearn):
+        worker = dict()
+        volumes = [('mongo_data/models', '/data/db')]
+        [('/opt/data/parameters_h5', '/parameters_h5'),
+         ('/opt/data/data_generator', '/data_generator'),
+         ('/.alp', '/root/.alp')]
+        t_volumes = make_volumes(root_folder, volumes)
+        worker['volumes'] = t_volumes
+        worker['name'] = 'sklearn_worker{}_{}'.format(name_suffix, i)
+        worker['container_name'] = 'tboquet/full7hc5workeralpsk'
+        worker['mode'] = '-d'
+        workers.append(worker)
+
+    for i in range(workers_keras):
+        worker = dict()
+        volumes = [('mongo_data/models', '/data/db')]
+        [('/opt/data/parameters_h5', '/parameters_h5'),
+         ('/opt/data/data_generator', '/data_generator'),
+         ('/.alp', '/root/.alp')]
+        t_volumes = make_volumes(root_folder, volumes)
+        worker['volumes'] = t_volumes
+        worker['name'] = 'sklearn_worker{}_{}'.format(name_suffix, i)
+        worker['container_name'] = 'tboquet/full7hc5workeralpk'
+        worker['NV_GPU'] = '0'
+        worker['mode'] = '-d'
+        workers.append(worker)
+
+    controlers_list = []
+    for i in range(controlers):
+        controler = dict()
+        volumes = [('mongo_data/models', '/data/db')]
+        [('/opt/data/parameters_h5', '/parameters_h5'),
+         ('/opt/data/data_generator', '/data_generator'),
+         ('/.alp', '/root/.alp')]
+        t_volumes = make_volumes(root_folder, volumes)
+        controler['volumes'] = t_volumes
+        controler['name'] = 'controler{}_{}'.format(name_suffix, i)
+        controler['container_name'] = 'tboquet/full7hc5controleralp'
+        controler['NV_GPU'] = '0'
+        controler['mode'] = '-d'
+        controlers_list.append(controler)
+
+    config = dict()
+    config['broker'] = broker
+    config['result_db'] = result_db
+    config['model_gen_db'] = model_db
+    config['workers'] = workers
+    config['controlers'] = controlers
+
+    return config
+
+
+def gen_alpdb_config(name_suffix=''):
+    if len(name_suffix) > 0:
+        name_suffix = '_{}'.format(name_suffix)
+
+    return {'db_engine': 'mongodb',
+            'host_adress': 'mongo_models{}'.format(name_suffix)}
+
+
+def gen_alpapp_config(name_suffix='', port_shift=0):
+    if len(name_suffix) > 0:
+        name_suffix = '_{}'.format(name_suffix)
+
+    port = 5672 + port_shift
+    broker_url = 'amqp://guest:guest@rabbitmq_sched{}:{}'
+
+    config = dict()
+    config['broker'] = broker_url.format(name_suffix, port)
+    cont_name = 'mongo_results{}'.format(name_suffix)
+    config['backend'] = 'mongodb://{}:27017'.format(cont_name)
+    config['path_h5'] = '/parameters_h5'
+
+    return config
+
+
+def gen_all_configs(name_suffix='', port_shift=0, root_folder=None,
+                          controlers=1, workers_sklearn=1, workers_keras=1):
+    alpapp = gen_alpapp_config(name_suffix, port_shift)
+    alpdb = gen_alpdb_config(name_suffix)
+    containers = gen_containers_config(name_suffix='', port_shift=0,
+                                              root_folder=None, controlers=1,
+                                              workers_sklearn=1,
+                                              workers_keras=1)
+    alpapp_json = json.dumps(alpapp, indent=4)
+    alpdb_json = json.dumps(alpdb, indent=4)
+    containers_json = json.dumps(containers, indent=4)
+    return alpapp_json, alpdb_json, containers_json
 
 
 class Conf(object):

--- a/src/alp/cli_utils.py
+++ b/src/alp/cli_utils.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 import subprocess
 from subprocess import PIPE
 import click

--- a/src/alp/cli_utils.py
+++ b/src/alp/cli_utils.py
@@ -363,12 +363,13 @@ def action_config(config, action, verbose=False, force=False):
 
 def make_volumes(root_folder, volumes):
     t_volumes = ['{}:{}'.format(os.path.join(root_folder, v_root), c_root)
-                    for v_root, c_root in volumes]
+                 for v_root, c_root in volumes]
     return t_volumes
 
 
-def gen_containers_config(name_suffix='', port_shift=0, root_folder=None,
-                          controlers=1, workers_sklearn=1, workers_keras=1):
+def gen_containers_config(conf_folder, name_suffix='', port_shift=0,
+                          root_folder=None, controlers=1, workers_sklearn=1,
+                          workers_keras=1):
     """ Generates containers config parsable with ALP CLI
 
     This function generates a JSON configuration usable with ALP CLI.
@@ -393,6 +394,7 @@ def gen_containers_config(name_suffix='', port_shift=0, root_folder=None,
         system. The support for multiple GPU machine is straightforward and
         will be added soon.
     """
+
     if len(name_suffix) > 0:
         name_suffix = '_{}'.format(name_suffix)
 
@@ -438,7 +440,7 @@ def gen_containers_config(name_suffix='', port_shift=0, root_folder=None,
         volumes = [('mongo_data/models', '/data/db')]
         [('/opt/data/parameters_h5', '/parameters_h5'),
          ('/opt/data/data_generator', '/data_generator'),
-         ('/.alp', '/root/.alp')]
+         (conf_folder, '/root/.alp')]
         t_volumes = make_volumes(root_folder, volumes)
         worker['volumes'] = t_volumes
         worker['name'] = 'sklearn_worker{}_{}'.format(name_suffix, i)
@@ -451,7 +453,7 @@ def gen_containers_config(name_suffix='', port_shift=0, root_folder=None,
         volumes = [('mongo_data/models', '/data/db')]
         [('/opt/data/parameters_h5', '/parameters_h5'),
          ('/opt/data/data_generator', '/data_generator'),
-         ('/.alp', '/root/.alp')]
+         (conf_folder, '/root/.alp')]
         t_volumes = make_volumes(root_folder, volumes)
         worker['volumes'] = t_volumes
         worker['name'] = 'sklearn_worker{}_{}'.format(name_suffix, i)
@@ -466,7 +468,7 @@ def gen_containers_config(name_suffix='', port_shift=0, root_folder=None,
         volumes = [('mongo_data/models', '/data/db')]
         [('/opt/data/parameters_h5', '/parameters_h5'),
          ('/opt/data/data_generator', '/data_generator'),
-         ('/.alp', '/root/.alp')]
+         (conf_folder, '/root/.alp')]
         t_volumes = make_volumes(root_folder, volumes)
         controler['volumes'] = t_volumes
         controler['name'] = 'controler{}_{}'.format(name_suffix, i)
@@ -509,14 +511,15 @@ def gen_alpapp_config(name_suffix='', port_shift=0):
     return config
 
 
-def gen_all_configs(name_suffix='', port_shift=0, root_folder=None,
-                          controlers=1, workers_sklearn=1, workers_keras=1):
+def gen_all_configs(conf_folder, name_suffix='', port_shift=0,
+                    root_folder=None, controlers=1, workers_sklearn=1,
+                    workers_keras=1):
     alpapp = gen_alpapp_config(name_suffix, port_shift)
     alpdb = gen_alpdb_config(name_suffix)
-    containers = gen_containers_config(name_suffix='', port_shift=0,
-                                              root_folder=None, controlers=1,
-                                              workers_sklearn=1,
-                                              workers_keras=1)
+    containers = gen_containers_config(conf_folder, name_suffix='',
+                                       port_shift=0, root_folder=None,
+                                       controlers=1, workers_sklearn=1,
+                                       workers_keras=1)
     alpapp_json = json.dumps(alpapp, indent=4)
     alpdb_json = json.dumps(alpdb, indent=4)
     containers_json = json.dumps(containers, indent=4)

--- a/tests/test_alp.py
+++ b/tests/test_alp.py
@@ -72,3 +72,16 @@ def test_pull():
     assert result.exit_code == 0
     result = runner.invoke(main, ['--verbose', 'pull', config_path])
     assert result.exit_code == 0
+
+
+def test_gen():
+    user_path = os.path.expanduser('~')
+    gen_dir = os.path.join(user_path, '.alp')
+    if not os.path.exists(gen_dir):
+        os.makedirs(gen_dir)
+    runner = CliRunner()
+    result = runner.invoke(main, ['genconfig'])
+    assert result.exit_code == 0
+    result = runner.invoke(main, ['--verbose', 'genconfig', '--outdir',
+                                  gen_dir])
+    assert result.exit_code == 0

--- a/tests/test_alp.py
+++ b/tests/test_alp.py
@@ -81,7 +81,11 @@ def test_gen():
         os.makedirs(gen_dir)
     runner = CliRunner()
     result = runner.invoke(main, ['genconfig'])
+    result = runner.invoke(main, ['genconfig', '--namesuf=test'])
     assert result.exit_code == 0
-    result = runner.invoke(main, ['--verbose', 'genconfig', '--outdir',
-                                  gen_dir])
+    result = runner.invoke(main, ['--verbose', 'genconfig',
+                                  '--outdir={}'.format(gen_dir)])
+    assert result.exit_code == 0
+    result = runner.invoke(main, ['--verbose', 'genconfig',
+                                  '--rootfolder={}'.format(gen_dir)])
     assert result.exit_code == 0


### PR DESCRIPTION
In this PR a new command is introduce to be able to quickly generate a base config for a system.
For now, we support only the generation for one machine.
A straightforward extension would be to integrate remote control over AWS instances and remote launches of workers using nvidia-docker. Documented in #78.

- [x] new command that generates a base config given a few parameters

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tboquet/python-alp/79)
<!-- Reviewable:end -->
